### PR TITLE
Feature/#47

### DIFF
--- a/src/__mocks__/window.ts
+++ b/src/__mocks__/window.ts
@@ -112,3 +112,43 @@ export function createShareMock() {
 export function removeShareMock() {
   delete (window.navigator as {share: any}).share
 }
+
+export function createCreateObjectURL(url?: string) {
+  Object.defineProperty(window.URL, "createObjectURL", {
+    value: jest.fn(() => url),
+    configurable: true,
+  })
+}
+
+export function removeCreateObjectURL() {
+  delete (window.URL as {createObjectURL: any}).createObjectURL
+}
+
+export function createRevokeObjectURL() {
+  Object.defineProperty(window.URL, "revokeObjectURL", {
+    value: jest.fn(),
+    configurable: true,
+  })
+}
+
+export function removeRevokeObjectURL() {
+  delete (window.URL as {revokeObjectURL: any}).revokeObjectURL
+}
+
+export function createOffscreenCanvas() {
+  Object.defineProperty(window, "OffscreenCanvas", {
+    value: jest.fn(() => ({
+      getContext: jest.fn(() => ({
+        drawImage: jest.fn(),
+      })),
+      convertToBlob: jest.fn(() =>
+        Promise.resolve(new Blob(["(mocked blob content)"]))
+      ),
+    })),
+    configurable: true,
+  })
+}
+
+export function removeOffscreenCanvas() {
+  delete (window as {OffscreenCanvas: any}).OffscreenCanvas
+}

--- a/src/__tests__/components/my/setting/Content.test.tsx
+++ b/src/__tests__/components/my/setting/Content.test.tsx
@@ -6,17 +6,28 @@ import {
   ProfileProvider,
   NicknameProvider,
   EmailProvider,
-  PasswordProvider
+  PasswordProvider,
 } from "@/components/my/setting/Context"
 import {Reducer} from "@/components"
 import type {TProps as TPortalProps} from "@/components/Portal"
 import {AUTH} from "@/constants/response-code"
 import {ROUTE} from "@/constants/service"
-import {createLocalStorageMock, removeLocalStorageMock} from "@/__mocks__/window"
+import {
+  createLocalStorageMock,
+  removeLocalStorageMock,
+} from "@/__mocks__/window"
 
 const Content = () => {
   return (
-    <Reducer components={[UserIdProvider, PasswordProvider, ProfileProvider, NicknameProvider, EmailProvider]}>
+    <Reducer
+      components={[
+        UserIdProvider,
+        PasswordProvider,
+        ProfileProvider,
+        NicknameProvider,
+        EmailProvider,
+      ]}
+    >
       <Component />
     </Reducer>
   )
@@ -27,55 +38,66 @@ const PASSWORD = "password"
 const PROFILE = "profile"
 const NICKNAME = "nickname"
 const EMAIL = "email"
+const SUBMIT_BUTTON = "submit button"
 
 const requestMock = jest.fn()
 jest.mock("../../../../hooks/use-request.ts", () => ({
   __esModule: true,
   default: () => ({
     request: requestMock,
-    isLoading: false
-  })
+    isLoading: false,
+  }),
 }))
 jest.mock("next/navigation", () => ({
   __esModule: true,
-  useRouter: jest.fn()
+  useRouter: jest.fn(),
 }))
 jest.mock("../../../../components/Loading.tsx", () => ({
   __esModule: true,
-  default: () => <>Loading...</>
+  default: () => <>Loading...</>,
 }))
 jest.mock("../../../../components/Portal.tsx", () => ({
   __esModule: true,
-  default: ({render}: TPortalProps) => <>{render()}</>
+  default: ({render}: TPortalProps) => <>{render()}</>,
 }))
 jest.mock("../../../../components/FlowAlert.tsx", () => ({
   __esModule: true,
-  default: ({isAlerting, onClose}: {isAlerting: boolean, onClose: () => void}) => (
+  default: ({
+    isAlerting,
+    onClose,
+  }: {
+    isAlerting: boolean
+    onClose: () => void
+  }) => (
     <>
       ErrorAlert {isAlerting ? "open" : "close"}
       <button onClick={onClose}>확인</button>
     </>
-  )
+  ),
 }))
 jest.mock("../../../../components/my/setting/UserId.tsx", () => ({
   __esModule: true,
-  default: () => <>{USER_ID}</>
+  default: () => <>{USER_ID}</>,
 }))
 jest.mock("../../../../components/my/setting/Password.tsx", () => ({
   __esModule: true,
-  default: () => <>{PASSWORD}</>
+  default: () => <>{PASSWORD}</>,
 }))
 jest.mock("../../../../components/my/setting/Profile.tsx", () => ({
   __esModule: true,
-  default: () => <>{PROFILE}</>
+  default: () => <>{PROFILE}</>,
 }))
 jest.mock("../../../../components/my/setting/Nickname.tsx", () => ({
   __esModule: true,
-  default: () => <>{NICKNAME}</>
+  default: () => <>{NICKNAME}</>,
 }))
 jest.mock("../../../../components/my/setting/Email.tsx", () => ({
   __esModule: true,
-  default: () => <>{EMAIL}</>
+  default: () => <>{EMAIL}</>,
+}))
+jest.mock("../../../../components/my/setting/SubmitButton.tsx", () => ({
+  __esModule: true,
+  default: () => <>{SUBMIT_BUTTON}</>,
 }))
 
 describe("Content", () => {
@@ -94,8 +116,8 @@ describe("Content", () => {
       data: {
         id: "userId",
         nickName: "nickname",
-        email: "email@domain.com"
-      }
+        email: "email@domain.com",
+      },
     })
 
     await waitFor(() => {
@@ -109,6 +131,7 @@ describe("Content", () => {
     const profile = screen.getByText(new RegExp(PROFILE))
     const nickname = screen.getByText(new RegExp(NICKNAME))
     const email = screen.getByText(new RegExp(EMAIL))
+    const submitButton = screen.getByText(new RegExp(SUBMIT_BUTTON))
     const errorAlert = screen.queryByText("ErrorAlert open")
 
     // then
@@ -119,6 +142,7 @@ describe("Content", () => {
     expect(profile).toBeInTheDocument()
     expect(nickname).toBeInTheDocument()
     expect(email).toBeInTheDocument()
+    expect(submitButton).toBeInTheDocument()
     expect(errorAlert).not.toBeInTheDocument()
   })
 
@@ -129,8 +153,8 @@ describe("Content", () => {
       data: {
         id: "userId",
         nickName: "nickname",
-        email: "email@domain.com"
-      }
+        email: "email@domain.com",
+      },
     })
 
     await waitFor(() => {
@@ -147,15 +171,15 @@ describe("Content", () => {
     // given
     const routerPushMock = jest.fn()
     ;(useRouter as jest.Mock).mockReturnValue({
-      push: routerPushMock
+      push: routerPushMock,
     })
     requestMock.mockResolvedValue({
       code: -1,
       data: {
         id: "userId",
         nickName: "nickname",
-        email: "email@domain.com"
-      }
+        email: "email@domain.com",
+      },
     })
 
     await waitFor(() => {

--- a/src/__tests__/components/my/setting/Password.test.tsx
+++ b/src/__tests__/components/my/setting/Password.test.tsx
@@ -26,16 +26,40 @@ jest.mock("../../../../components/SecretInput.tsx", () => ({
 }))
 
 describe("Password", () => {
-  it("유저 비밀번호 인풋, 비밀번호 확인 인풋을 올바르게 렌더링한다.", () => {
+  it("비밀번호 인풋, 비밀번호 확인 인풋을 올바르게 렌더링한다.", () => {
     // given, when
     render(<Password />)
 
-    const passwordInput = screen.getAllByPlaceholderText("비밀번호를 입력해주세요.")[0]
-    const passwordConfirmInput = screen.getAllByPlaceholderText("비밀번호를 입력해주세요.")[1]
+    const passwordInput = screen.getAllByPlaceholderText(
+      "비밀번호 변경을 원하시면 입력해주세요."
+    )[0]
+    const passwordConfirmInput = screen.getAllByPlaceholderText(
+      "비밀번호 변경을 원하시면 입력해주세요."
+    )[1]
 
     // then
     expect(passwordInput).toBeInTheDocument()
     expect(passwordConfirmInput).toBeInTheDocument()
+  })
+
+  it("비밀번호 인풋에 아무런 글자도 입력되지 않았으면 유효한 비밀번호라고 렌더링한다.", () => {
+    // given
+    render(<Password />)
+
+    const passwordInput = screen.getAllByPlaceholderText(
+      "비밀번호 변경을 원하시면 입력해주세요."
+    )[0]
+    const validityLights = screen.getAllByRole("status")
+
+    // when
+    fireEvent.change(passwordInput, {
+      target: {value: ""},
+    })
+
+    // then
+    validityLights.forEach((validityLight) => {
+      expect(validityLight.classList).toContain("valid-light")
+    })
   })
 
   it("입력된 유저 비밀번호 영문 포함 여부에 따라 유효성 light 상태가 변한다.", () => {
@@ -44,7 +68,9 @@ describe("Password", () => {
 
     const PASSWORD_WITHOUT_ENGLISH = "1234"
     const PASSWORD_WITH_ENGLISH = "1234password"
-    const passwordInput = screen.getAllByPlaceholderText("비밀번호를 입력해주세요.")[0]
+    const passwordInput = screen.getAllByPlaceholderText(
+      "비밀번호 변경을 원하시면 입력해주세요."
+    )[0]
     const validityLight = screen.getAllByRole("status")[0]
 
     // when
@@ -70,7 +96,9 @@ describe("Password", () => {
 
     const PASSWORD_WITHOUT_NUMBER = "password"
     const PASSWORD_WITH_NUMBER = "1234password"
-    const passwordInput = screen.getAllByPlaceholderText("비밀번호를 입력해주세요.")[0]
+    const passwordInput = screen.getAllByPlaceholderText(
+      "비밀번호 변경을 원하시면 입력해주세요."
+    )[0]
     const validityLight = screen.getAllByRole("status")[1]
 
     // when
@@ -96,7 +124,9 @@ describe("Password", () => {
 
     const PASSWORD_WITHOUT_SPECIAL_CHARACTER = "password"
     const PASSWORD_WITH_SPECIAL_CHARACTER = "1234password!@"
-    const passwordInput = screen.getAllByPlaceholderText("비밀번호를 입력해주세요.")[0]
+    const passwordInput = screen.getAllByPlaceholderText(
+      "비밀번호 변경을 원하시면 입력해주세요."
+    )[0]
     const validityLight = screen.getAllByRole("status")[2]
 
     // when
@@ -122,7 +152,9 @@ describe("Password", () => {
 
     const SHORT_PASSWORD = "pw"
     const LONG_PASSWORD = "password"
-    const passwordInput = screen.getAllByPlaceholderText("비밀번호를 입력해주세요.")[0]
+    const passwordInput = screen.getAllByPlaceholderText(
+      "비밀번호 변경을 원하시면 입력해주세요."
+    )[0]
     const validityLight = screen.getAllByRole("status")[3]
 
     // when
@@ -147,8 +179,12 @@ describe("Password", () => {
     render(<Password />)
 
     const password = "password"
-    const passwordInput = screen.getAllByPlaceholderText("비밀번호를 입력해주세요.")[0]
-    const passwordConfirmInput = screen.getAllByPlaceholderText("비밀번호를 입력해주세요.")[1]
+    const passwordInput = screen.getAllByPlaceholderText(
+      "비밀번호 변경을 원하시면 입력해주세요."
+    )[0]
+    const passwordConfirmInput = screen.getAllByPlaceholderText(
+      "비밀번호 변경을 원하시면 입력해주세요."
+    )[1]
     const validityLight = screen.getAllByRole("status")[4]
 
     // when

--- a/src/__tests__/components/my/setting/Profile.test.tsx
+++ b/src/__tests__/components/my/setting/Profile.test.tsx
@@ -1,12 +1,26 @@
 import {render, screen, fireEvent} from "@testing-library/react"
+import type {ReactNode} from "react"
 import Component from "@/components/my/setting/Profile"
 import {ProfileStore} from "@/components/my/setting/Context"
+import {ROUTE} from "@/constants/service"
 
 const setProfileMock = jest.fn()
+const getSearchParamsMock = jest.fn()
+const routerPushMock = jest.fn()
+const requestMock = jest.fn()
 
 const Profile = () => {
   return (
-    <ProfileStore.Provider value={{profile: "https://test-domain.com/profile", setProfile: setProfileMock}}>
+    <ProfileStore.Provider
+      value={{
+        profile: {
+          type: "uploadUrl",
+          url: "https://test-domain.com/profile",
+          data: "",
+        },
+        setProfile: setProfileMock,
+      }}
+    >
       <Component />
     </ProfileStore.Provider>
   )
@@ -14,28 +28,62 @@ const Profile = () => {
 
 jest.mock("next/image", () => ({
   __esModule: true,
-  default: ({src, onClick}: {src: string, onClick: () => void}) => <img src={src} alt="프로필 이미지" onClick={onClick} />
+  default: ({src, onClick}: {src: string; onClick: () => void}) => (
+    <img src={src} alt="프로필 이미지" onClick={onClick} />
+  ),
 }))
-const requestMock = jest.fn()
+jest.mock("next/navigation", () => ({
+  __esModule: true,
+  useSearchParams: () => ({
+    get: getSearchParamsMock,
+  }),
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}))
+jest.mock("react-image-crop", () => ({
+  __esModule: true,
+  default: () => <></>,
+}))
 jest.mock("../../../../hooks/use-request.ts", () => ({
   __esModule: true,
   default: () => ({
     request: requestMock,
-    isLoading: false
-  })
+    isLoading: false,
+  }),
+}))
+jest.mock("../../../../hooks/use-image-crop.ts", () => ({
+  __esModule: true,
+  default: () => ({
+    convertBlobToDataUrl: jest.fn(),
+    makeCropAsBlobImage: jest.fn().mockReturnValue({}),
+    revokeBlob: jest.fn(),
+    revokeImage: jest.fn(),
+    image: "image",
+  }),
 }))
 jest.mock("../../../../components/Loading.tsx", () => ({
   __esModule: true,
-  default: () => <div>loading...</div>
+  default: () => <div>loading...</div>,
+}))
+jest.mock("../../../../components/BottomSheet.tsx", () => ({
+  __esModule: true,
+  default: ({children}: {children: ReactNode}) => <>{children}</>,
 }))
 
 describe("Profile", () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   it("총 7개의 이미지와 '내 사진 가져오기' 버튼이 올바르게 렌더링한다.", () => {
     // given, when
     render(<Profile />)
 
     const profileImages = screen.getAllByRole("img")
-    const uploadProfileButton = screen.getByRole("button", {name: /내 사진 가져오기/})
+    const uploadProfileButton = screen.getByRole("button", {
+      name: /내 사진 가져오기/,
+    })
 
     // then
     expect(profileImages.length).toEqual(7)
@@ -43,7 +91,36 @@ describe("Profile", () => {
   })
 
   // TODO: API 연동 후 '리스트에서 선택하기' 프로필 이미지 업데이트 추가
-  // TODO: '내 사진 가져오기' 버튼 클릭 후 인터렉션 추가
+
+  it("사진을 업로드하면 프로필 설정 페이지로 이동한다", () => {
+    // given
+    const file = new File([], "test.png", {type: "image/png"})
+
+    render(<Profile />)
+
+    const fileInput = screen.getByLabelText("내 사진 가져오기")
+
+    // when
+    fireEvent.change(fileInput, {target: {files: [file]}})
+
+    // then
+    expect(routerPushMock).toHaveBeenCalledWith(ROUTE.MY_SETTING_PROFILE)
+  })
+
+  it("'사진 가져오기' 버튼을 누르면 내 설정 페이지로 이동한다.", () => {
+    // given
+    render(<Profile />)
+
+    const getImageButton = screen.getByRole("button", {
+      name: "사진 가져오기",
+    })
+
+    // when
+    fireEvent.click(getImageButton)
+
+    // then
+    expect(routerPushMock).toHaveBeenCalledWith(ROUTE.MY_SETTING)
+  })
 
   it("'리스트에서 선택하기'의 있는 프로필 이미지를 눌렀을 때 'selected' 클래스가 추가되고 선택된 프로필 이미지가 변경된다.", () => {
     // given
@@ -56,12 +133,20 @@ describe("Profile", () => {
     fireEvent.click(defaultProfileImages[0])
 
     // then
-    expect(setProfileMock).toHaveBeenCalledWith(defaultProfileImages[0].src)
+    expect(setProfileMock).toHaveBeenCalledWith({
+      type: "uploadUrl",
+      url: defaultProfileImages[0].src,
+      data: defaultProfileImages[0].src,
+    })
 
     // when
     fireEvent.click(defaultProfileImages[5])
 
     // then
-    expect(setProfileMock).toHaveBeenCalledWith(defaultProfileImages[5].src)
+    expect(setProfileMock).toHaveBeenCalledWith({
+      type: "uploadUrl",
+      url: defaultProfileImages[5].src,
+      data: defaultProfileImages[5].src,
+    })
   })
 })

--- a/src/__tests__/components/my/setting/SubmitButton.test.tsx
+++ b/src/__tests__/components/my/setting/SubmitButton.test.tsx
@@ -1,0 +1,363 @@
+import {render, screen, fireEvent, waitFor} from "@testing-library/react"
+import type {ReactNode} from "react"
+import Component from "@/components/my/setting/SubmitButton"
+import {
+  PasswordStore,
+  ProfileStore,
+  NicknameStore,
+  EmailStore,
+} from "@/components/my/setting/Context"
+import type {TProps as TPortalProps} from "@/components/Portal"
+import {createLocalStorageMock} from "@/__mocks__/window"
+import {removeLocalStorageMock} from "@/__mocks__/window"
+import {
+  INVALID_EMAILS,
+  INVALID_PASSWORDS,
+  VALID_EMAIL,
+  VALID_PASSWORD,
+} from "@/__mocks__/fixtures/input"
+import {AUTH} from "@/constants/response-code"
+import {ROUTE} from "@/constants/service"
+
+const SubmitButton = ({
+  password = "",
+  passwordConfirm = "",
+  nickname = "",
+  email = "",
+}: {
+  password?: string
+  passwordConfirm?: string
+  nickname?: string
+  email?: string
+}) => {
+  return (
+    <PasswordStore.Provider
+      value={{
+        password,
+        passwordConfirm,
+        handlePassword: jest.fn(),
+        handlePasswordConfirm: jest.fn(),
+      }}
+    >
+      <ProfileStore.Provider
+        value={{
+          profile: {type: "uploadUrl", data: "", url: ""},
+          setProfile: jest.fn(),
+        }}
+      >
+        <NicknameStore.Provider
+          value={{nickname, setNickname: jest.fn(), handleNickname: jest.fn()}}
+        >
+          <EmailStore.Provider
+            value={{email, setEmail: jest.fn(), handleEmail: jest.fn()}}
+          >
+            <Component />
+          </EmailStore.Provider>
+        </NicknameStore.Provider>
+      </ProfileStore.Provider>
+    </PasswordStore.Provider>
+  )
+}
+
+const routerPushMock = jest.fn()
+const requestMock = jest.fn()
+
+jest.mock("next/navigation", () => ({
+  __esModule: true,
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}))
+jest.mock("../../../../hooks/use-request.ts", () => ({
+  __esModule: true,
+  default: () => ({
+    request: requestMock,
+    isLoading: false,
+  }),
+}))
+jest.mock("../../../../components/Portal.tsx", () => ({
+  __esModule: true,
+  default: ({render}: TPortalProps) => <>{render()}</>,
+}))
+jest.mock("../../../../components/FlowAlert.tsx", () => ({
+  __esModule: true,
+  default: ({
+    isAlerting,
+    content,
+    onClose,
+  }: {
+    isAlerting: boolean
+    content: ReactNode
+    onClose: () => void
+  }) => (
+    <>
+      {isAlerting ? content : ""}
+      <button onClick={onClose}>확인</button>
+    </>
+  ),
+}))
+
+describe("SubmitButton", () => {
+  beforeEach(() => {
+    createLocalStorageMock()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    removeLocalStorageMock()
+  })
+
+  it("'저장하기' 버튼을 렌더링한다.", async () => {
+    // given, when
+    await waitFor(() => {
+      render(<SubmitButton />)
+    })
+
+    const submitButton = screen.getByRole("button", {name: "저장하기"})
+
+    // then
+    expect(submitButton).toBeInTheDocument()
+  })
+
+  it("'저장하기' 버튼을 클릭할 때 비밀번호를 입력했지만 유효하지 않은 비밀번호면 '비밀번호 조건을 충족하지 않았습니다.'라는 문구가 포함된 얼럿이 노출된다.", async () => {
+    // given
+    await waitFor(() => {
+      render(<SubmitButton password={INVALID_PASSWORDS[0]} />)
+    })
+
+    const submitButton = screen.getByRole("button", {name: "저장하기"})
+
+    // when
+    fireEvent.click(submitButton)
+
+    // then
+    const flowAlert = screen.getByText(/비밀번호 조건을 충족하지 않았습니다./)
+
+    expect(flowAlert).toBeInTheDocument()
+  })
+
+  it("'저장하기' 버튼을 클릭할 때 비밀번호를 입력했지만 비밀번호 확인과 다르면 '비밀번호가 일치하지 않습니다.'라는 문구가 포함된 얼럿이 노출된다.", async () => {
+    // given
+    await waitFor(() => {
+      render(<SubmitButton password={VALID_PASSWORD} />)
+    })
+
+    const submitButton = screen.getByRole("button", {name: "저장하기"})
+
+    // when
+    fireEvent.click(submitButton)
+
+    // then
+    const flowAlert = screen.getByText(/비밀번호가 일치하지 않습니다./)
+
+    expect(flowAlert).toBeInTheDocument()
+  })
+
+  it("'저장하기' 버튼을 클릭할 때 비밀번호 확인을 입력했지만 비밀번호와 다르면 '비밀번호가 일치하지 않습니다.'라는 문구가 포함된 얼럿이 노출된다.", async () => {
+    // given
+    await waitFor(() => {
+      render(
+        <SubmitButton
+          password={VALID_PASSWORD}
+          passwordConfirm={VALID_PASSWORD + "wrong"}
+        />
+      )
+    })
+
+    const submitButton = screen.getByRole("button", {name: "저장하기"})
+
+    // when
+    fireEvent.click(submitButton)
+
+    // then
+    const flowAlert = screen.getByText(/비밀번호가 일치하지 않습니다./)
+
+    expect(flowAlert).toBeInTheDocument()
+  })
+
+  it("'저장하기' 버튼을 클릭할 때 닉네임을 입력하지 않으면 '닉네임이 입력되지 않았습니다.'라는 문구가 포함된 얼럿이 노출된다.", async () => {
+    // given
+    await waitFor(() => {
+      render(
+        <SubmitButton
+          password={VALID_PASSWORD}
+          passwordConfirm={VALID_PASSWORD}
+        />
+      )
+    })
+
+    const submitButton = screen.getByRole("button", {name: "저장하기"})
+
+    // when
+    fireEvent.click(submitButton)
+
+    // then
+    const flowAlert = screen.getByText(/닉네임이 입력되지 않았습니다./)
+
+    expect(flowAlert).toBeInTheDocument()
+  })
+
+  it("'저장하기' 버튼을 클릭할 때 이메일을 입력했지만 유효하지 않은 이메일이면 '이메일 형식이 올바르지 않습니다.'라는 문구가 포함된 얼럿이 노출된다.", async () => {
+    // given
+    await waitFor(() => {
+      render(
+        <SubmitButton
+          password={VALID_PASSWORD}
+          passwordConfirm={VALID_PASSWORD}
+          nickname="nickname"
+          email={INVALID_EMAILS[0]}
+        />
+      )
+    })
+
+    const submitButton = screen.getByRole("button", {name: "저장하기"})
+
+    // when
+    fireEvent.click(submitButton)
+
+    // then
+    const flowAlert = screen.getByText(/이메일 형식이 올바르지 않습니다./)
+
+    expect(flowAlert).toBeInTheDocument()
+  })
+
+  it("모든 입력이 유효하면 API를 호출한다.", async () => {
+    // given
+    requestMock.mockResolvedValue({
+      code: 0,
+      data: {
+        nickName: "",
+        profile: "",
+      },
+    })
+
+    await waitFor(() => {
+      render(
+        <SubmitButton
+          password={VALID_PASSWORD}
+          passwordConfirm={VALID_PASSWORD}
+          nickname="nickname"
+          email={VALID_EMAIL}
+        />
+      )
+    })
+
+    const submitButton = screen.getByRole("button", {name: "저장하기"})
+
+    // when
+    fireEvent.click(submitButton)
+
+    // then
+    await waitFor(() => {
+      expect(requestMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("'저장하기' 버튼을 누를 때 호출하는 API 응답이 1016이면 '이미 존재하는 이메일입니다.'라는 문구가 포함된 얼럿이 노출된다.", async () => {
+    // given
+    requestMock.mockResolvedValue({
+      code: AUTH.USER.DUPLICATED_EMAIL,
+      data: {
+        nickName: "",
+        profile: "",
+      },
+    })
+
+    await waitFor(() => {
+      render(
+        <SubmitButton
+          password={VALID_PASSWORD}
+          passwordConfirm={VALID_PASSWORD}
+          nickname="nickname"
+          email={VALID_EMAIL}
+        />
+      )
+    })
+
+    const submitButton = screen.getByRole("button", {name: "저장하기"})
+
+    // when
+    fireEvent.click(submitButton)
+
+    // then
+    const florAlert = await screen.findByText(/이미 존재하는 이메일입니다./)
+
+    expect(florAlert).toBeInTheDocument()
+  })
+
+  it("'저장하기' 버튼을 누를 때 호출하는 API 응답이 정상이면 '변경 사항이 저장되었습니다.'라는 문구가 포함된 얼럿이 노출되고 로컬 스토리지에 닉네임과 프로필을 저장한다.", async () => {
+    // given
+    const nickName = "test nickName"
+    const profile = "test profile"
+    requestMock.mockResolvedValue({
+      code: 0,
+      data: {
+        nickName,
+        profile,
+      },
+    })
+
+    await waitFor(() => {
+      render(
+        <SubmitButton
+          password={VALID_PASSWORD}
+          passwordConfirm={VALID_PASSWORD}
+          nickname="nickname"
+          email={VALID_EMAIL}
+        />
+      )
+    })
+
+    const submitButton = screen.getByRole("button", {name: "저장하기"})
+
+    // when
+    fireEvent.click(submitButton)
+
+    // then
+    const florAlert = await screen.findByText(/변경 사항이 저장되었습니다./)
+
+    expect(florAlert).toBeInTheDocument()
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      "nickName",
+      nickName
+    )
+    expect(window.localStorage.setItem).toHaveBeenCalledWith("profile", profile)
+  })
+
+  it("'저장하기' 버튼을 누를 때 호출하는 API 응답이 정상일 때 노출되는 얼럿에서 '확인' 버튼을 누르면 마이페이지로 이동한다.", async () => {
+    // given
+    requestMock.mockResolvedValue({
+      code: 0,
+      data: {
+        nickName: "",
+        profile: "",
+      },
+    })
+
+    await waitFor(() => {
+      render(
+        <SubmitButton
+          password={VALID_PASSWORD}
+          passwordConfirm={VALID_PASSWORD}
+          nickname="nickname"
+          email={VALID_EMAIL}
+        />
+      )
+    })
+
+    const submitButton = screen.getByRole("button", {name: "저장하기"})
+
+    fireEvent.click(submitButton)
+
+    const confirmButton = await screen.findAllByText("확인")
+
+    // when
+    fireEvent.click(confirmButton[1])
+
+    // then
+    expect(routerPushMock).toHaveBeenCalledWith(ROUTE.MY_PAGE)
+  })
+})

--- a/src/__tests__/hooks/use-image-crop.test.tsx
+++ b/src/__tests__/hooks/use-image-crop.test.tsx
@@ -1,0 +1,222 @@
+import {fireEvent, render, screen, waitFor} from "@testing-library/react"
+import useImageCrop from "@/hooks/use-image-crop"
+import {
+  createCreateObjectURL,
+  createOffscreenCanvas,
+  createRevokeObjectURL,
+  removeCreateObjectURL,
+  removeOffscreenCanvas,
+  removeRevokeObjectURL,
+} from "@/__mocks__/window"
+
+const DEFAULT_IMAGE_SRC = "http://localhost/"
+
+describe("useImageCrop", () => {
+  beforeEach(() => {
+    createCreateObjectURL("blob://www.test.com")
+    createRevokeObjectURL()
+    createOffscreenCanvas()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    removeCreateObjectURL()
+    removeRevokeObjectURL()
+    removeOffscreenCanvas()
+  })
+
+  it("'convertBlobToDataUrl'은 file을 읽어 이미지로 변환한다.", async () => {
+    // given
+    const Component = ({file}: {file: File}) => {
+      const aspect = 1
+      const {image, convertBlobToDataUrl} = useImageCrop(aspect)
+
+      return (
+        <>
+          <button onClick={() => convertBlobToDataUrl(file)}>click</button>
+          <img src={image} alt="image" />
+        </>
+      )
+    }
+
+    const imageFile = new File([], "text.png", {type: "image/png"})
+    render(<Component file={imageFile} />)
+
+    const convertButton = screen.getByRole("button", {name: "click"})
+
+    // when
+    await waitFor(() => {
+      fireEvent.click(convertButton)
+    })
+
+    // then
+    const image = screen.getByAltText("image") as HTMLImageElement
+
+    await waitFor(() => {
+      expect(image.src).not.toEqual(DEFAULT_IMAGE_SRC)
+    })
+  })
+
+  it("'revokeBlob'은 ref가 없다면 'URL.revokeObjectURL'을 호출하지 않는다.", async () => {
+    // given
+    const Component = () => {
+      const aspect = 1
+      const {revokeBlob} = useImageCrop(aspect)
+
+      return <button onClick={revokeBlob}>revoke</button>
+    }
+
+    render(<Component />)
+
+    const revokeButton = screen.getByRole("button", {name: "revoke"})
+
+    // when
+    fireEvent.click(revokeButton)
+
+    // then
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled()
+  })
+
+  it("'revokeBlob'은 ref가 있다면 'URL.revokeObjectURL'을 호출한다.", async () => {
+    // given
+    const Component = () => {
+      const aspect = 1
+      const {
+        imageRef,
+        image,
+        setCompletedCrop,
+        makeCropAsBlobImage,
+        revokeBlob,
+      } = useImageCrop(aspect)
+
+      return (
+        <>
+          <button
+            onClick={() =>
+              setCompletedCrop({
+                x: 0,
+                y: 0,
+                unit: "px",
+                width: 100,
+                height: 100,
+              })
+            }
+          >
+            set
+          </button>
+          <button onClick={() => makeCropAsBlobImage()}>make</button>
+          <button onClick={revokeBlob}>revoke</button>
+          <img ref={imageRef} src={image} alt="image" />
+        </>
+      )
+    }
+
+    render(<Component />)
+
+    const setButton = screen.getByRole("button", {name: "set"})
+    const makeButton = screen.getByRole("button", {name: "make"})
+    const revokeButton = screen.getByRole("button", {name: "revoke"})
+
+    fireEvent.click(setButton)
+    await waitFor(() => {
+      fireEvent.click(makeButton)
+    })
+
+    // when
+    fireEvent.click(revokeButton)
+
+    // then
+    expect(URL.revokeObjectURL).toHaveBeenCalled()
+  })
+
+  it("'revokeImage'은 image가 없다면 'URL.revokeObjectURL'을 호출하지 않는다.", async () => {
+    // given
+    const Component = () => {
+      const aspect = 1
+      const {revokeImage} = useImageCrop(aspect)
+
+      return <button onClick={revokeImage}>revoke</button>
+    }
+
+    render(<Component />)
+
+    const revokeButton = screen.getByRole("button", {name: "revoke"})
+
+    // when
+    fireEvent.click(revokeButton)
+
+    // then
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled()
+  })
+
+  it("'revokeImage'은 image가 있다면 'URL.revokeObjectURL'을 호출하고 이미지를 초기화한다.", async () => {
+    // given
+    const Component = ({file}: {file: File}) => {
+      const aspect = 1
+      const {
+        imageRef,
+        image,
+        convertBlobToDataUrl,
+        setCompletedCrop,
+        makeCropAsBlobImage,
+        revokeImage,
+      } = useImageCrop(aspect)
+
+      return (
+        <>
+          <button onClick={() => convertBlobToDataUrl(file)}>convert</button>
+          <button
+            onClick={() =>
+              setCompletedCrop({
+                x: 0,
+                y: 0,
+                unit: "px",
+                width: 100,
+                height: 100,
+              })
+            }
+          >
+            set
+          </button>
+          <button onClick={() => makeCropAsBlobImage()}>make</button>
+          <button onClick={revokeImage}>revoke</button>
+          <img ref={imageRef} src={image} alt="image" />
+        </>
+      )
+    }
+    const imageFile = new File([], "text.png", {type: "image/png"})
+    render(<Component file={imageFile} />)
+
+    const convertButton = screen.getByRole("button", {name: "convert"})
+    const setButton = screen.getByRole("button", {name: "set"})
+    const makeButton = screen.getByRole("button", {name: "make"})
+    const revokeButton = screen.getByRole("button", {name: "revoke"})
+
+    // when
+    await waitFor(() => {
+      fireEvent.click(convertButton)
+    })
+
+    // then
+    const image = screen.getByAltText("image") as HTMLImageElement
+
+    await waitFor(() => {
+      expect(image.src).not.toEqual(DEFAULT_IMAGE_SRC)
+    })
+
+    // when
+    fireEvent.click(setButton)
+    await waitFor(() => {
+      fireEvent.click(makeButton)
+    })
+    fireEvent.click(revokeButton)
+
+    // then
+
+    expect(URL.revokeObjectURL).toHaveBeenCalled()
+    expect(image.src).toEqual(DEFAULT_IMAGE_SRC)
+  })
+})

--- a/src/components/my/setting/Content.tsx
+++ b/src/components/my/setting/Content.tsx
@@ -43,7 +43,8 @@ const Content = () => {
       setUserId(data.id)
       setProfile({
         type: "uploadUrl",
-        data: Storage.get("profile") ?? "",
+        url: Storage.get("profile") ?? "",
+        data: "",
       })
       setNickname(data.nickName)
       setEmail(data.email ?? "")

--- a/src/components/my/setting/Context.tsx
+++ b/src/components/my/setting/Context.tsx
@@ -9,7 +9,8 @@ type TProps = {
 
 type TProfile = {
   type: "dataUrl" | "uploadUrl"
-  data: string
+  url: string
+  data: string | Blob
 }
 
 const UserIdStore = createContext<{
@@ -62,6 +63,7 @@ const ProfileStore = createContext<{
   profile: {
     type: "uploadUrl",
     data: "",
+    url: "",
   },
   setProfile: function () {},
 })
@@ -70,6 +72,7 @@ const ProfileProvider = ({children}: TProps) => {
   const [profile, setProfile] = useState<TProfile>({
     type: "uploadUrl",
     data: "",
+    url: "",
   })
 
   return (

--- a/src/components/my/setting/Password.tsx
+++ b/src/components/my/setting/Password.tsx
@@ -15,7 +15,7 @@ const Password = () => {
         <span className="input-name mb-2">PW 변경</span>
         <SecretInput
           className="input radius-sm mb-2"
-          placeholder="비밀번호를 입력해주세요."
+          placeholder="비밀번호 변경을 원하시면 입력해주세요."
           minLength={8}
           maxLength={20}
           required
@@ -26,27 +26,35 @@ const Password = () => {
       <section className="validity mb-2">
         <div
           className={`${
-            VALIDATOR.ENGLISH.test(password) ? "valid" : "invalid"
+            VALIDATOR.ENGLISH.test(password) || password.length === 0
+              ? "valid"
+              : "invalid"
           }-light`}
           role="status"
         />
         <span>영문</span>
         <div
           className={`${
-            VALIDATOR.NUMBER.test(password) ? "valid" : "invalid"
+            VALIDATOR.NUMBER.test(password) || password.length === 0
+              ? "valid"
+              : "invalid"
           }-light`}
           role="status"
         />
         <span>숫자</span>
         <div
           className={`${
-            VALIDATOR.SPECIAL_CHARACTER.test(password) ? "valid" : "invalid"
+            VALIDATOR.SPECIAL_CHARACTER.test(password) || password.length === 0
+              ? "valid"
+              : "invalid"
           }-light`}
           role="status"
         />
         <span>특수 문자</span>
         <div
-          className={`${password.length >= 8 ? "valid" : "invalid"}-light`}
+          className={`${
+            password.length >= 8 || password.length === 0 ? "valid" : "invalid"
+          }-light`}
           role="status"
         />
         <span>8글자 이상</span>
@@ -56,7 +64,7 @@ const Password = () => {
         <span className="input-name mb-2">PW 재입력</span>
         <SecretInput
           className="input radius-sm mb-2"
-          placeholder="비밀번호를 입력해주세요."
+          placeholder="비밀번호 변경을 원하시면 입력해주세요."
           minLength={8}
           maxLength={20}
           required

--- a/src/components/my/setting/Profile.tsx
+++ b/src/components/my/setting/Profile.tsx
@@ -72,10 +72,14 @@ const Profile = () => {
   }
 
   async function makeCropAsProfile() {
-    const profileUrl = await makeCropAsBlobImage()
+    const {url: profileUrl, blob: profileBlob} = await makeCropAsBlobImage(
+      216,
+      216
+    )
     setProfile({
       type: "dataUrl",
-      data: profileUrl,
+      url: profileUrl,
+      data: profileBlob,
     })
     closeBottomSheet()
   }
@@ -84,6 +88,7 @@ const Profile = () => {
     revokeBlob()
     setProfile({
       type: "uploadUrl",
+      url: defaultProfiles[index],
       data: defaultProfiles[index],
     })
   }
@@ -101,9 +106,9 @@ const Profile = () => {
     <div className="profile-wrapper input-wrapper mb-2">
       <span className="input-name mb-2">프로필 사진</span>
       <div className="selected f-center mr-4">
-        {profile.data ? (
+        {profile.url ? (
           <Image
-            src={profile.data}
+            src={profile.url}
             className="profile"
             alt="프로필 이미지"
             loading="eager"

--- a/src/components/my/setting/Profile.tsx
+++ b/src/components/my/setting/Profile.tsx
@@ -49,7 +49,7 @@ const Profile = () => {
   const isOpenSearchParams = searchParams.get(OPEN) === PROFILE_EDIT
 
   useEffect(() => {
-    if (!!image) {
+    if (!!image && isOpenSearchParams) {
       openBottomSheet()
     } else {
       closeBottomSheet()
@@ -76,6 +76,7 @@ const Profile = () => {
       216,
       216
     )
+
     setProfile({
       type: "dataUrl",
       url: profileUrl,

--- a/src/components/my/setting/SubmitButton.tsx
+++ b/src/components/my/setting/SubmitButton.tsx
@@ -33,7 +33,7 @@ const SubmitButton = () => {
     if (password && !VALIDATOR.PASSWORD.test(password)) {
       setErrorMessage(
         <>
-          비밀번호의 조건을 충족하지 않았습니다.
+          비밀번호 조건을 충족하지 않았습니다.
           <br />
           다시 한 번 확인해주세요.
         </>

--- a/src/constants/service.ts
+++ b/src/constants/service.ts
@@ -10,7 +10,7 @@ export const ROUTE = {
   MAIN: "/",
   MY_PAGE: "/my",
   MY_SETTING: "/my/setting",
-  MY_SETTING_PROFILE: `my/setting?${OPEN}=${PROFILE_EDIT}`,
+  MY_SETTING_PROFILE: `/my/setting?${OPEN}=${PROFILE_EDIT}`,
   MY_PROJECTS: `/my?${OPEN}=${ALL_PROJECTS}`,
   MY_ROLLING_PAPERS: `/my?${OPEN}=${ALL_RECEIVED_ROLLING_PAPERS}`,
   OAUTH_MIDDLEWARE: "/oauth-middleware",

--- a/src/hooks/use-image-crop.ts
+++ b/src/hooks/use-image-crop.ts
@@ -46,9 +46,9 @@ export default function useImageCrop(aspect: number) {
 
   function convertBlobToDataUrl(file: File) {
     const reader = new FileReader()
-    reader.addEventListener("load", () =>
+    reader.addEventListener("load", () => {
       setImage(reader.result?.toString() || "")
-    )
+    })
     reader.readAsDataURL(file)
   }
 

--- a/src/hooks/use-image-crop.ts
+++ b/src/hooks/use-image-crop.ts
@@ -73,7 +73,10 @@ export default function useImageCrop(aspect: number) {
     setCompletedCrop(initialCrop)
   }
 
-  async function makeCropAsBlobImage() {
+  async function makeCropAsBlobImage(
+    targetWidth?: number,
+    targetHeight?: number
+  ) {
     if (!completedCrop || !imageRef.current) {
       throw new Error("completed crop 없음")
     }
@@ -89,10 +92,9 @@ export default function useImageCrop(aspect: number) {
 
     const scaleX = imageRef.current.naturalWidth / imageRef.current.width
     const scaleY = imageRef.current.naturalHeight / imageRef.current.height
-    const targetSize = 216
 
-    offscreen.width = targetSize
-    offscreen.height = targetSize
+    offscreen.width = targetWidth ?? completedCrop.width * scaleX
+    offscreen.height = targetHeight ?? completedCrop.height * scaleY
 
     ctx.drawImage(
       imageRef.current,
@@ -102,8 +104,8 @@ export default function useImageCrop(aspect: number) {
       completedCrop.height * scaleY,
       0,
       0,
-      targetSize,
-      targetSize
+      offscreen.width,
+      offscreen.width
     )
 
     const blob = await offscreen.convertToBlob({
@@ -114,7 +116,10 @@ export default function useImageCrop(aspect: number) {
     const url = URL.createObjectURL(blob)
     blobRef.current = url
 
-    return url
+    return {
+      blob,
+      url,
+    }
   }
 
   function revokeBlob() {

--- a/src/hooks/use-request.ts
+++ b/src/hooks/use-request.ts
@@ -5,7 +5,7 @@ import useLogOut from "./use-log-out"
 type TRequestParameter = {
   path: string
   method?: "get" | "post" | "put" | "delete"
-  body?: Object
+  body?: Object | FormData
 }
 
 export default function useRequest() {
@@ -32,16 +32,23 @@ export default function useRequest() {
 
       latestRequest.set(path, currentTime)
 
+      const isForm = body instanceof FormData
       const data = await fetch(
         `${process.env.NEXT_PUBLIC_API_HOST}/api${path}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-          },
-          method,
-          body: body ? JSON.stringify(body) : null,
-          signal: controller.signal,
-        }
+        isForm
+          ? {
+              method,
+              body,
+              signal: controller.signal,
+            }
+          : {
+              headers: {
+                "Content-Type": "application/json",
+              },
+              method,
+              body: body ? JSON.stringify(body) : null,
+              signal: controller.signal,
+            }
       )
 
       if (!data.ok) {


### PR DESCRIPTION
이슈 링크: #47 

계정 정보 변경 시 JSON으로 보냈던 부분 폼 데이터로 보내도록 수정

## 내용

<컴포넌트>

- 내 설정 정보 내 컴포넌트
  - `src/components/my/setting/*.tsx`

<훅>

- API 요청 시 폼 데이터 보낼 수 있도록 수정
  - `src/hooks/use-request.ts`
- crop을 blob으로 변환할 때 blob 사이즈 함수 밖에서 제어할 수 있도록 수정
  - `src/hooks/use-image-crop.ts`

